### PR TITLE
Fix/empty xor

### DIFF
--- a/Equativ.RoaringBitmaps.Tests/RoaringBitmapTests.cs
+++ b/Equativ.RoaringBitmaps.Tests/RoaringBitmapTests.cs
@@ -505,6 +505,32 @@ public class RoaringBitmapTests
     }
     
     [Fact]
+    public void BitmapContainer_Xor_WithItself_HasZeroCardinality()
+    {
+        ushort[] data = Enumerable.Range(0, Container.MaxSize + 200)
+            .Select(i => (ushort)i)
+            .ToArray();
+        
+        BitmapContainer rb = BitmapContainer.Create(data);
+        Container selfXor = rb ^ rb;
+
+        Assert.Equal(0, selfXor.Cardinality);
+    }
+    
+    [Fact]
+    public void Xor_WithItselfLarger_EqualsEmpty()
+    {
+        int[] data = Enumerable.Range(0, Container.MaxSize + 200)
+            .ToArray();
+        
+        var rb = RoaringBitmap.Create(data);
+        var selfXor = rb ^ rb;
+        var empty = RoaringBitmap.Create([]);
+        
+        Assert.True(selfXor.Equals(empty), "both are empty");
+    }
+    
+    [Fact]
     public void XorPartiallyArrayContainer()
     {
         var rb = RoaringBitmap.Create(Enumerable.Range(1000, 200));

--- a/Equativ.RoaringBitmaps.Tests/RoaringBitmapTests.cs
+++ b/Equativ.RoaringBitmaps.Tests/RoaringBitmapTests.cs
@@ -489,7 +489,21 @@ public class RoaringBitmapTests
         var comparison = firstList.Union(secondList).OrderBy(t => t).ToList();
         Assert.Equal(comparison, rbList);
     }
-
+    
+    [Fact]
+    public void Xor_WithItself_EqualsToEmpty()
+    {
+        var rb = RoaringBitmap.Create(10, 20);
+        var selfXor = rb ^ rb;
+        var empty = RoaringBitmap.Create();
+        
+        // Pre-conditions showing both are empty
+        Assert.Equal(0, selfXor.Cardinality);
+        Assert.Equal(0, empty.Cardinality);
+        
+        Assert.True(selfXor.Equals(empty), "both are empty");
+    }
+    
     [Fact]
     public void XorPartiallyArrayContainer()
     {

--- a/Equativ.RoaringBitmaps/RoaringArray.cs
+++ b/Equativ.RoaringBitmaps/RoaringArray.cs
@@ -241,9 +241,14 @@ internal class RoaringArray : IEquatable<RoaringArray>
             {
                 if (xKey == yKey)
                 {
-                    keys.Add(xKey);
-                    containers.Add(x._values[xPos] ^ y._values[yPos]);
-                    size++;
+                    var c = x._values[xPos] ^ y._values[yPos];
+                    if (c.Cardinality > 0)
+                    {
+                        keys.Add(xKey);
+                        containers.Add(c);
+                        size++;
+                    }
+
                     xPos++;
                     yPos++;
                     if (xPos == xLength || yPos == yLength)


### PR DESCRIPTION
XOR on self did not produce same result as empty, which seem wrong.

Happens only for array, not for `RoaringBitmap`.