### PR TITLE
Relying on UnitializedArray

### DIFF
--- a/Equativ.RoaringBitmaps/ArrayContainer.cs
+++ b/Equativ.RoaringBitmaps/ArrayContainer.cs
@@ -61,7 +61,7 @@ internal class ArrayContainer : Container, IEquatable<ArrayContainer>
 
     internal static ArrayContainer Create(BitmapContainer bc)
     {
-        var data = new ushort[bc.Cardinality];
+        var data =  GC.AllocateUninitializedArray<ushort>(bc.Cardinality);
         var cardinality = bc.FillArray(data);
         var result = new ArrayContainer(cardinality, data);
         return result;

--- a/Equativ.RoaringBitmaps/BitmapContainer.cs
+++ b/Equativ.RoaringBitmaps/BitmapContainer.cs
@@ -15,7 +15,7 @@ internal class BitmapContainer : Container, IEquatable<BitmapContainer>
 
     static BitmapContainer()
     {
-        var data = new ulong[BitmapLength];
+        var data = GC.AllocateUninitializedArray<ulong>(BitmapLength);
         for (var i = 0; i < BitmapLength; i++)
         {
             data[i] = ulong.MaxValue;
@@ -131,7 +131,7 @@ internal class BitmapContainer : Container, IEquatable<BitmapContainer>
 
     private static ulong[] Clone(ulong[] data)
     {
-        var result = new ulong[BitmapLength];
+        var result = GC.AllocateUninitializedArray<ulong>(BitmapLength);
         Buffer.BlockCopy(data, 0, result, 0, BitmapLength * sizeof(ulong));
         return result;
     }
@@ -323,7 +323,7 @@ internal class BitmapContainer : Container, IEquatable<BitmapContainer>
 
     public static BitmapContainer Deserialize(BinaryReader binaryReader, int cardinality)
     {
-        var data = new ulong[BitmapLength];
+        var data = GC.AllocateUninitializedArray<ulong>(BitmapLength);
         for (var i = 0; i < BitmapLength; i++)
         {
             data[i] = binaryReader.ReadUInt64();


### PR DESCRIPTION
Tiny pill to speed up Bitmap containers. Taking arrays without pre-zero-ing them when possible.