### PR TITLE
Go for nine

### DIFF
--- a/Equativ.RoaringBitmaps.Benchmarks/Equativ.RoaringBitmaps.Benchmarks.csproj
+++ b/Equativ.RoaringBitmaps.Benchmarks/Equativ.RoaringBitmaps.Benchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>

--- a/Equativ.RoaringBitmaps.Datasets/Equativ.RoaringBitmaps.Datasets.csproj
+++ b/Equativ.RoaringBitmaps.Datasets/Equativ.RoaringBitmaps.Datasets.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Equativ.RoaringBitmaps.Tests/Equativ.RoaringBitmaps.Tests.csproj
+++ b/Equativ.RoaringBitmaps.Tests/Equativ.RoaringBitmaps.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Equativ.RoaringBitmaps/Equativ.RoaringBitmaps.csproj
+++ b/Equativ.RoaringBitmaps/Equativ.RoaringBitmaps.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageProjectUrl>https://github.com/equativ/Equativ.RoaringBitmaps</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/equativ/Equativ.RoaringBitmaps/blob/main/LICENSE</PackageLicenseUrl>
     <PackageTags>Equativ.RoaringBitmaps</PackageTags>


### PR DESCRIPTION
There is a range of improvements in .NET 9 that are to help, like less border checks, on-stack allocates.

Following the benchmark, `AND` op ratio to CRoaring dropped from 2.25 to 2.03.

Feels like we can do more to get us closer to CRoaring.