### PR TITLE
Add ArrayContainer array operation tests and container benchmarks

### DIFF
--- a/Equativ.RoaringBitmaps.Benchmarks/ContainerOperatorBenchmark.cs
+++ b/Equativ.RoaringBitmaps.Benchmarks/ContainerOperatorBenchmark.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+
+namespace Equativ.RoaringBitmaps.Benchmark;
+
+[MemoryDiagnoser(false)]
+public class ContainerOperatorBenchmark
+{
+    private Container[] _lhs = Array.Empty<Container>();
+    private Container[] _rhs = Array.Empty<Container>();
+
+    [Params(1000)]
+    public int Size { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var rnd = new Random(42);
+        _lhs = new Container[Size];
+        _rhs = new Container[Size];
+        for (int i = 0; i < Size; i++)
+        {
+            var start1 = rnd.Next(0, ushort.MaxValue - 200);
+            var start2 = rnd.Next(0, ushort.MaxValue - 200);
+            _lhs[i] = ArrayContainer.Create(Enumerable.Range(start1, 100).Select(x => (ushort)x).ToArray());
+            _rhs[i] = ArrayContainer.Create(Enumerable.Range(start2, 100).Select(x => (ushort)x).ToArray());
+        }
+    }
+
+    [Benchmark]
+    public int Or()
+    {
+        int total = 0;
+        for (int i = 0; i < _lhs.Length; i++)
+        {
+            total += (_lhs[i] | _rhs[i]).Cardinality;
+        }
+        return total;
+    }
+
+    [Benchmark]
+    public int Xor()
+    {
+        int total = 0;
+        for (int i = 0; i < _lhs.Length; i++)
+        {
+            total += (_lhs[i] ^ _rhs[i]).Cardinality;
+        }
+        return total;
+    }
+
+    [Benchmark]
+    public int And()
+    {
+        int total = 0;
+        for (int i = 0; i < _lhs.Length; i++)
+        {
+            total += (_lhs[i] & _rhs[i]).Cardinality;
+        }
+        return total;
+    }
+
+    [Benchmark]
+    public int AndNot()
+    {
+        int total = 0;
+        for (int i = 0; i < _lhs.Length; i++)
+        {
+            total += Container.AndNot(_lhs[i], _rhs[i]).Cardinality;
+        }
+        return total;
+    }
+}

--- a/Equativ.RoaringBitmaps.Tests/ArrayContainerArrayOpsTests.cs
+++ b/Equativ.RoaringBitmaps.Tests/ArrayContainerArrayOpsTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Equativ.RoaringBitmaps.Tests;
+
+public class ArrayContainerArrayOpsTests
+{
+    private static bool BitSet(ulong[] bitmap, int value)
+    {
+        int index = value >> 6;
+        ulong mask = 1UL << value;
+        return (bitmap[index] & mask) != 0;
+    }
+
+    [Fact]
+    public void OrArray_EmptyBitmap_SetsAllBits()
+    {
+        var ac = ArrayContainer.Create(new ushort[] {1, 63, 64, 500});
+        var bitmap = new ulong[1024];
+
+        int added = ac.OrArray(bitmap);
+
+        Assert.Equal(ac.Cardinality, added);
+        Assert.True(BitSet(bitmap, 1));
+        Assert.True(BitSet(bitmap, 63));
+        Assert.True(BitSet(bitmap, 64));
+        Assert.True(BitSet(bitmap, 500));
+}
+
+    [Fact]
+    public void OrArray_WithExistingBits_AddsOnlyMissing()
+    {
+        var ac = ArrayContainer.Create(new ushort[] {1, 200, 500});
+        var bitmap = new ulong[1024];
+        // pre-set bit 1 and 200
+        bitmap[1 >> 6] |= 1UL << 1;
+        bitmap[200 >> 6] |= 1UL << 200;
+
+        int added = ac.OrArray(bitmap);
+
+        Assert.Equal(1, added); // only value 500 was added
+        Assert.True(BitSet(bitmap, 1));
+        Assert.True(BitSet(bitmap, 200));
+        Assert.True(BitSet(bitmap, 500));
+    }
+
+    [Fact]
+    public void XorArray_EmptyBitmap_TogglesBits()
+    {
+        var ac = ArrayContainer.Create(new ushort[] {2, 100});
+        var bitmap = new ulong[1024];
+
+        int delta = ac.XorArray(bitmap);
+
+        Assert.Equal(ac.Cardinality, delta);
+        Assert.True(BitSet(bitmap, 2));
+        Assert.True(BitSet(bitmap, 100));
+    }
+
+    [Fact]
+    public void XorArray_WithExistingBits_TogglesOff()
+    {
+        var ac = ArrayContainer.Create(new ushort[] {2, 100});
+        var bitmap = new ulong[1024];
+        bitmap[2 >> 6] |= 1UL << 2; // set bit 2
+
+        int delta = ac.XorArray(bitmap);
+
+        Assert.Equal(0, delta); // one added, one removed
+        Assert.False(BitSet(bitmap, 2));
+        Assert.True(BitSet(bitmap, 100));
+    }
+
+    [Fact]
+    public void AndNotArray_NoBitsSet_NoChange()
+    {
+        var ac = ArrayContainer.Create(new ushort[] {3, 30});
+        var bitmap = new ulong[1024];
+
+        int delta = ac.AndNotArray(bitmap);
+
+        Assert.Equal(0, delta);
+        Assert.False(BitSet(bitmap, 3));
+        Assert.False(BitSet(bitmap, 30));
+    }
+
+    [Fact]
+    public void AndNotArray_RemovesExistingBits()
+    {
+        var ac = ArrayContainer.Create(new ushort[] {3, 30});
+        var bitmap = new ulong[1024];
+        bitmap[3 >> 6] |= 1UL << 3;
+        bitmap[30 >> 6] |= 1UL << 30;
+        bitmap[40 >> 6] |= 1UL << 40;
+
+        int delta = ac.AndNotArray(bitmap);
+
+        Assert.Equal(-2, delta);
+        Assert.False(BitSet(bitmap, 3));
+        Assert.False(BitSet(bitmap, 30));
+        Assert.True(BitSet(bitmap, 40));
+    }
+}

--- a/Equativ.RoaringBitmaps.Tests/ContainerOperatorTests.cs
+++ b/Equativ.RoaringBitmaps.Tests/ContainerOperatorTests.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Equativ.RoaringBitmaps.Tests;
+
+public class ContainerOperatorTests
+{
+    private static List<int> ToList(Container c)
+    {
+        var list = new List<int>();
+        c.EnumerateFill(list, 0);
+        return list;
+    }
+
+    [Fact]
+    public void Or_ArrayContainers_ThroughBaseOperator()
+    {
+        Container a = ArrayContainer.Create(new ushort[] {1, 3});
+        Container b = ArrayContainer.Create(new ushort[] {3, 5});
+
+        Container result = a | b;
+
+        Assert.Equal(new[] {1,3,5}, ToList(result));
+    }
+
+    [Fact]
+    public void Xor_MixedContainers_ThroughBaseOperator()
+    {
+        Container a = ArrayContainer.Create(new ushort[] {1, 2});
+        Container b = BitmapContainer.Create(new ushort[] {2, 4});
+
+        Container result = a ^ b;
+
+        Assert.Equal(new[] {1,4}, ToList(result));
+    }
+
+    [Fact]
+    public void And_MixedContainers_ThroughBaseOperator()
+    {
+        Container a = ArrayContainer.Create(new ushort[] {10, 11, 12});
+        Container b = BitmapContainer.Create(new ushort[] {11, 13});
+
+        Container result = a & b;
+
+        Assert.Equal(new[] {11}, ToList(result));
+    }
+
+    [Fact]
+    public void AndNot_MixedContainers()
+    {
+        Container a = ArrayContainer.Create(new ushort[] {8, 9, 10});
+        Container b = BitmapContainer.Create(new ushort[] {9});
+
+        Container result = Container.AndNot(a, b);
+
+        Assert.Equal(new[] {8,10}, ToList(result));
+    }
+}


### PR DESCRIPTION
The goal is to draw a base line for these ops. Despite vectorization seem possible, it may not be worth it since arrays might be too small.

These tests will be a base line for us to measure.

Local (dev) machine results:

BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.4652)
AMD Ryzen 7 6800H with Radeon Graphics, 1 CPU, 16 logical and 8 physical cores
.NET SDK 9.0.200
  [Host]     : .NET 8.0.13 (8.0.1325.6609), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.13 (8.0.1325.6609), X64 RyuJIT AVX2


| Method | Size | Mean      | Error    | StdDev   | Allocated |
|------- |----- |----------:|---------:|---------:|----------:|
| Or     | 1000 | 131.29 us | 2.522 us | 2.359 us | 445.31 KB |
| Xor    | 1000 | 129.00 us | 2.352 us | 2.200 us | 445.31 KB |
| And    | 1000 |  78.00 us | 0.887 us | 0.786 us |    250 KB |
| AndNot | 1000 | 105.83 us | 1.315 us | 1.230 us |    250 KB 

Monster dev machine:

BenchmarkDotNet v0.14.0, Windows 10 (10.0.19045.6093/22H2/2022Update)
AMD Ryzen 9 3900XT, 1 CPU, 24 logical and 12 physical cores
.NET SDK 9.0.100
  [Host]     : .NET 8.0.7 (8.0.724.31311), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.7 (8.0.724.31311), X64 RyuJIT AVX2


| Method | Size | Mean      | Error    | StdDev   | Allocated |
|------- |----- |----------:|---------:|---------:|----------:|
| Or     | 1000 | 134.52 us | 2.532 us | 2.487 us | 445.31 KB |
| Xor    | 1000 | 119.92 us | 2.008 us | 1.878 us | 445.31 KB |
| And    | 1000 |  70.56 us | 1.791 us | 5.168 us |    250 KB |
| AndNot | 1000 | 117.32 us | 2.273 us | 3.332 us |    250 KB |

Moster should be ~10% faster for single-core ops & have ~10 % better memory -> only 'AND & XOr' are affected:

https://cpu.userbenchmark.com/Compare/AMD-Ryzen-9-3900XT-vs-AMD-Ryzen-7-6800H/m1202614vsm1786492
